### PR TITLE
Remove unneeded type specification

### DIFF
--- a/docs/src/tutorial1.md
+++ b/docs/src/tutorial1.md
@@ -38,7 +38,7 @@ Now that the scattering problem is set up, we solve for the cylindrical harmonic
 coefficients and potential densities, respectively, by using
 
 ```julia
-beta,inner = solve_particle_scattering(k0, kin, P, sp::ScatteringProblem, θ_i)
+beta,inner = solve_particle_scattering(k0, kin, P, sp, θ_i)
 ```
 
 These can be used to calculate the scattered field at any point in space using

--- a/docs/src/tutorial1.md
+++ b/docs/src/tutorial1.md
@@ -59,7 +59,7 @@ plot(points[:,1]/λ0, abs.(u))
 
 Similarly, a 2D plot can be drawn of the total field around the scatterer:
 ```julia
-plot_near_field(k0, kin, P, sp::ScatteringProblem, θ_i;
+plot_near_field(k0, kin, P, sp, θ_i;
     x_points = 201, y_points = 201, border = 0.5λ0*[-1;1;-1;1])
 ```
 


### PR DESCRIPTION
The first tutorial in the docs uses a type specification for variable `sp` that is not needed---in fact, the example works even without it.