### PR TITLE
Explicitly import PyPlots

### DIFF
--- a/docs/src/tutorial1.md
+++ b/docs/src/tutorial1.md
@@ -52,6 +52,11 @@ appropriate method:
 #calculate field on the x-axis passing through the particle
 points = [linspace(-0.5λ0, 0.5λ0, 200)  zeros(200)]
 u = calc_near_field(k0, kin, P, sp, points, θ_i)
+```
+
+We use `PyPlot` to display the result:
+```julia
+using PyPlot
 plot(points[:,1]/λ0, abs.(u))
 ```
 


### PR DESCRIPTION
Without an explicit `using PyPlot` command, the tutorial produces an error.